### PR TITLE
added mac specific guards.

### DIFF
--- a/Hdf5/Hdf5File.cpp
+++ b/Hdf5/Hdf5File.cpp
@@ -33,8 +33,8 @@
 #include <stdexcept>
 #include <ctime>
 
-// Linux build
-#ifdef __linux__
+// Linux and macOS build
+#if defined(__linux__) || defined(__APPLE__)
   #include <unistd.h>
 #endif
 
@@ -166,7 +166,11 @@ bool Hdf5File::canAccess(const string& fileName)
   #endif
 
   #ifdef _WIN64
-     return (_access_s(fileName.c_str(), 0) == 0 );
+    return (_access_s(fileName.c_str(), 0) == 0);
+  #endif
+
+  #ifdef __APPLE__
+    return (access(fileName.c_str(), F_OK) == 0);
   #endif
 }// end of canAccess
 //----------------------------------------------------------------------------------------------------------------------

--- a/Hdf5/Hdf5FileHeader.cpp
+++ b/Hdf5/Hdf5FileHeader.cpp
@@ -420,10 +420,10 @@ void Hdf5FileHeader::setHostInfo()
 {
   char hostName[256];
 
-  // Linux build
-  #ifdef __linux__
-    gethostname(hostName, 256);
-  #endif
+// Unix-like systems (Linux and macOS)
+#if defined(__linux__) || defined(__APPLE__)
+  gethostname(hostName, 256);
+#endif
 
   // Windows build
   #ifdef _WIN64

--- a/Hdf5/Hdf5FileHeader.cpp
+++ b/Hdf5/Hdf5FileHeader.cpp
@@ -433,11 +433,6 @@ void Hdf5FileHeader::setHostInfo()
     WSACleanup();
   #endif
 
-  // Apple build
-  #ifdef __APPLE__
-    gethostname(hostName, 256);
-  #endif
-
   mHeaderValues[FileHeaderItems::kHostName]
           = Logger::formatMessage("%s (%s)", hostName, Parameters::getInstance().getProcessorName().c_str());
 }// end of setHostName

--- a/Hdf5/Hdf5FileHeader.cpp
+++ b/Hdf5/Hdf5FileHeader.cpp
@@ -44,6 +44,11 @@
   #pragma comment(lib, "Ws2_32.lib")
 #endif
 
+// Apple build
+#ifdef __APPLE__
+  #include <unistd.h>
+#endif
+
 #include <Hdf5/Hdf5FileHeader.h>
 #include <Parameters/Parameters.h>
 #include <Logger/Logger.h>
@@ -415,18 +420,22 @@ void Hdf5FileHeader::setHostInfo()
 {
   char hostName[256];
 
-  //Linux build
+  // Linux build
   #ifdef __linux__
     gethostname(hostName, 256);
   #endif
 
-  //Windows build
+  // Windows build
   #ifdef _WIN64
     WSADATA wsaData;
     WSAStartup(MAKEWORD(2, 2), &wsaData);
-	  gethostname(hostName, 256);
-
+    gethostname(hostName, 256);
     WSACleanup();
+  #endif
+
+  // Apple build
+  #ifdef __APPLE__
+    gethostname(hostName, 256);
   #endif
 
   mHeaderValues[FileHeaderItems::kHostName]

--- a/Hdf5/Hdf5FileHeader.cpp
+++ b/Hdf5/Hdf5FileHeader.cpp
@@ -44,8 +44,8 @@
   #pragma comment(lib, "Ws2_32.lib")
 #endif
 
-// Apple build
-#ifdef __APPLE__
+// Unix-like systems (Linux and macOS)
+#if defined(__linux__) || defined(__APPLE__)
   #include <unistd.h>
 #endif
 

--- a/KSpaceSolver/KSpaceFirstOrderSolver.cpp
+++ b/KSpaceSolver/KSpaceFirstOrderSolver.cpp
@@ -472,6 +472,14 @@ size_t KSpaceFirstOrderSolver::getMemoryUsage() const
 
     return pmc.PeakWorkingSetSize >> 20;
   #endif
+
+  // macOS build
+  #ifdef __APPLE__
+    struct rusage memUsage;
+    getrusage(RUSAGE_SELF, &memUsage);
+
+    return memUsage.ru_maxrss >> 10;
+  #endif
 }// end of getMemoryUsage
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/KSpaceSolver/KSpaceFirstOrderSolver.cpp
+++ b/KSpaceSolver/KSpaceFirstOrderSolver.cpp
@@ -29,16 +29,14 @@
  * If not, see [http://www.gnu.org/licenses/](http://www.gnu.org/licenses/).
  */
 
-// Linux build
-#ifdef __linux__
+// Unix-like systems (Linux and macOS)
+#ifdef defined(__linux__) || defined(__APPLE__)
   #include <sys/resource.h>
 #elif _WIN64 // Windows build
   #define _USE_MATH_DEFINES
   #include <Windows.h>
   #include <Psapi.h>
   #pragma comment(lib, "Psapi.lib")
-#elif __APPLE__
-  #include <sys/resource.h>
 #endif
 
 #ifdef _OPENMP

--- a/KSpaceSolver/KSpaceFirstOrderSolver.cpp
+++ b/KSpaceSolver/KSpaceFirstOrderSolver.cpp
@@ -472,14 +472,12 @@ size_t KSpaceFirstOrderSolver::getMemoryUsage() const
 
     return pmc.PeakWorkingSetSize >> 20;
   #endif
-
-  // macOS build
-  #ifdef __APPLE__
-    struct rusage memUsage;
-    getrusage(RUSAGE_SELF, &memUsage);
-
-    return memUsage.ru_maxrss >> 10;
-  #endif
+// Unix-like systems (Linux and macOS)
+#if defined(__linux__) || defined(__APPLE__)
+  struct rusage memUsage;
+  getrusage(RUSAGE_SELF, &memUsage);
+  return memUsage.ru_maxrss >> 10;
+#endif
 }// end of getMemoryUsage
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CPU_FLAGS = -m64 -mcpu=apple-m1 -mtune=native
 OPT = -O3 -ffast-math -fassociative-math 
 
 # Debug flags
-DEBUG = -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize
+DEBUG = -g -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize
 
 # Profile flags
 PROFILE = 


### PR DESCRIPTION
In the process of implementing checkpointing, I discovered that various Mac specific guards weren't implemented.

In the case of checkpointing, the function responsible for determing if a hdf5 file existed (or not) was silently returning false as it didn't have a Mac directive.

This pull request adds Mac directives in places where there are equivalent win/linux directives.

It also address some bogus memory calculations and processor naming for Macs.

E.g.:

```
┌───────────────────────────────────────────────────────────────┐
│                   kspaceFirstOrder-OMP v1.3                   │
├───────────────────────────────────────────────────────────────┤
│ Reading simulation configuration:                        Done │
│ File format version:                                      1.2 │
│ Number of CPU threads:                                     14 │
│ Processor name:                                  Apple M4 Pro │
├───────────────────────────────────────────────────────────────┤
│                      Simulation details                       │
├───────────────────────────────────────────────────────────────┤
│ Domain dimensions:                             64 x 128 x 128 │
│ Medium type:                                               3D │
│ Simulation time steps:                                    530 │
├───────────────────────────────────────────────────────────────┤
│ Input file:  /Users/xxxxxxxxxx/tmp/kwave_input.h5             │
│ Input file:  /Users/xxxxxxxxxx/tmp/kwave_output_test.h5       │
│ Input file:  /Users/xxxxxxxxxx/tmp/kwave_checkpoint.h5        │
├───────────────────────────────────────────────────────────────┤
│ Checkpoint time steps:                                    100 │
│ Compression level:                                          0 │
│ Print progress interval:                                   5% │
├───────────────────────────────────────────────────────────────┤
│                        Medium details                         │
├───────────────────────────────────────────────────────────────┤
│ Wave propagation:                                      Linear │
│ Absorption type:                                     Lossless │
│ Medium parameters:                                Homogeneous │
├───────────────────────────────────────────────────────────────┤
│                        Source details                         │
├───────────────────────────────────────────────────────────────┤
│ Initial pressure source p0:                                   │
│ + Memory usage:                                        4.00MB │
├───────────────────────────────────────────────────────────────┤
│                        Sensor details                         │
├───────────────────────────────────────────────────────────────┤
│ Sensor mask type:                                       Index │
│ Sampling begins at time step:                               1 │
├───────────────────────────────────────────────────────────────┤
│ Pressure sensor p_raw                                         │
│ + File usage:                                         23.58MB │
├───────────────────────────────────────────────────────────────┤
│                        Initialization                         │
├───────────────────────────────────────────────────────────────┤
│ Memory allocation:                                       Done │
│ Data loading:                                                 │
│ + Reading input file:                                    Done │
│ + Reading checkpoint file:                               Done │
│ + Reading output file:                                   Done │
│ Elapsed time:                                           0.01s │
├───────────────────────────────────────────────────────────────┤
│ Recovered from time step:                                 500 │
├───────────────────────────────────────────────────────────────┤
│ FFT plans creation:                                      Done │
│ Pre-processing phase:                                    Done │
│ Elapsed time:                                           0.01s │
├───────────────────────────────────────────────────────────────┤
│                    Computational resources                    │
├───────────────────────────────────────────────────────────────┤
│ Current host memory in use:                           86320MB │
│ Expected output file size:                               23MB │
├───────────────────────────────────────────────────────────────┤
│                          Simulation                           │
├──────────┬────────────────┬──────────────┬────────────────────┤
│ Progress │  Elapsed time  │  Time to go  │  Est. finish time  │
├──────────┼────────────────┼──────────────┼────────────────────┤
│    94%   │        0.007s  │      0.172s  │  01/05/25 10:47:30 │
│    99%   │        0.152s  │      0.024s  │  01/05/25 10:47:30 │
├──────────┴────────────────┴──────────────┴────────────────────┤
│ Elapsed time:                                           0.18s │
├───────────────────────────────────────────────────────────────┤
│ Sampled data post-processing:                            Done │
│ Elapsed time:                                           0.00s │
├───────────────────────────────────────────────────────────────┤
│                            Summary                            │
├───────────────────────────────────────────────────────────────┤
│ Peak memory in use:                                   89856MB │
├───────────────────────────────────────────────────────────────┤
│ This leg execution time:                                0.22s │
│ Total execution time:                                  75.81s │
├───────────────────────────────────────────────────────────────┤
│                       End of computation                      │
└───────────────────────────────────────────────────────────────┘
```