### PR TITLE
Fixing NaNs on macOS arm64 absorption by disabling fast-math flags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OPENMP = -Xpreprocessor -fopenmp
 CPU_FLAGS = -m64 -mcpu=apple-m1 -mtune=native
 
 # Use maximum optimization
-OPT = -O3 -ffast-math -fassociative-math 
+OPT = -O3 -fno-fast-math -ffp-contract=fast -fno-finite-math-only -fno-strict-aliasing 
 
 # Debug flags
 DEBUG = -g -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize


### PR DESCRIPTION
I've been experimenting with absorption in k-wave-python, and found that this produces NaN values on darwin macs (I've not been able to experiment with intel macs). The latest version of this repository is an improvement in the sense that absorption no longer gives NaNs, but still gives differing results compared to the linux binaries. Consider the following script. Attached is also the files I'm using in the script.

Changing KW_DIR from the path which points to k-wave-omp-darwin to None results in failing the first assert statement, since the array has NaN values. Using the k-wave-omp-darwin binary will pass the first assert statement, but not the second one comparing the results against k-wave-python on a linux machine. 

After a bit of digging, I found the culprit to be (I think) the fast-math flags in the makefile. Changing line 16 to disable those flags and running this script again, we find agreement in the absorbing medium. 

Please let me know if anything is unclear/wrong!

```
from copy import deepcopy
import numpy as np
from kwave.data import Vector
from kwave.kgrid import kWaveGrid
from kwave.kmedium import kWaveMedium
from kwave.ksensor import kSensor
from kwave.ksource import kSource
from kwave.kspaceFirstOrder2D import kspaceFirstOrder2D
from kwave.options.simulation_execution_options import SimulationExecutionOptions
from kwave.options.simulation_options import SimulationOptions
from kwave.utils.filters import smooth
from kwave.utils.mapgen import make_disc
from pathlib import Path

PML_size = 0  # size of the PML in grid points
N = Vector([128, 256]) - 2 * PML_size  # number of grid points
d = Vector([0.1e-3, 0.1e-3])  # grid point spacing [m]
kgrid = kWaveGrid(N, d)

medium_lossless = kWaveMedium(sound_speed=1540, density=1000)
medium_absorbing = kWaveMedium(
    sound_speed=1540, density=1000, alpha_coeff=10.75, alpha_power=1.5
)

# create initial pressure distribution using makeDisc
disc_magnitude = 5  # [Pa]
disc_pos = Vector([60, 140])  # [grid points]
disc_radius = 5  # [grid points]
disc_2 = disc_magnitude * make_disc(N, disc_pos, disc_radius)

disc_pos = Vector([30, 110])  # [grid points]
disc_radius = 8  # [grid points]
disc_1 = disc_magnitude * make_disc(N, disc_pos, disc_radius)

# smooth the initial pressure distribution and restore the magnitude
p0 = smooth(disc_1 + disc_2, restore_max=True)

# assign to the source structure
source = kSource()
source.p0 = p0

sensor = kSensor()
sensor.mask = np.zeros(N)
sensor.mask[0] = 1

kgrid.makeTime(medium_lossless.sound_speed)

simulation_options = SimulationOptions(
    pml_inside=False,
    pml_size=PML_size,
    smooth_p0=False,
    save_to_disk=True,
    data_cast="single",
)

KW_DIR = Path("k-wave-omp-darwin/kspaceFirstOrder-OMP")
#KW_DIR = None

execution_options = SimulationExecutionOptions(
    is_gpu_simulation=False, verbose_level=2, show_sim_log=True, binary_path=KW_DIR
)


print("Computing Lossless")
sensor_data_lossless = kspaceFirstOrder2D(
    kgrid,
    source,
    deepcopy(sensor),
    medium_lossless,
    simulation_options,
    execution_options,
)["p"]

print("Computing Absorbing")
sensor_data_absorbing = kspaceFirstOrder2D(
    kgrid,
    source,
    deepcopy(sensor),
    medium_absorbing,
    simulation_options,
    execution_options,
)["p"]

assert not np.any(np.isnan(sensor_data_absorbing))

linux_out = np.load("sensor_data_absorbing.npy")

assert np.allclose(sensor_data_absorbing, linux_out, atol=2e-6)
```
Attached:
[sensor_data_absorbing.npy.zip](https://github.com/user-attachments/files/22537953/sensor_data_absorbing.npy.zip)

[absorption_test.h5.zip](https://github.com/user-attachments/files/22537955/absorption_test.h5.zip)

